### PR TITLE
Update terminal_assistant.py

### DIFF
--- a/terminal_assistant.py
+++ b/terminal_assistant.py
@@ -53,14 +53,14 @@ def check_for_config():
 
 check_for_config()
 
-openai.api_base = "http://localhost:1234/v1"
+openai.api_base = "http://localhost:5111/v1"
 openai.api_key = "YOUR_API_KEY_HERE"
 API_KEY = config['AUTH']['googleapi_key']
 SEARCH_ENGINE_ID = config['AUTH']['googleapi_search_id']
 ENDPOINT = "https://www.googleapis.com/customsearch/v1"
 
 
-def ask_gpt(prompt, model="local-model", tokens=2500):
+def ask_gpt(prompt, model="local-model"):
     """
     Function to interact with the GPT model.
     """
@@ -70,9 +70,7 @@ def ask_gpt(prompt, model="local-model", tokens=2500):
             {"role": "system", "content": "I am your helpful assistant"},
             {"role": "user", "content": prompt}
         ],
-        max_tokens=tokens,
-        n=1,
-        stop=None,
+
         temperature=0.7,
     )
     return response.choices[0].message['content']
@@ -94,7 +92,7 @@ def recognize_speech():
 
     with sr.Microphone() as source:
         print("Speak:")
-        audio = recognizer.listen(source)
+        audio = recognizer.listen(source,timeout=15, phrase_time_limit=20)
 
     try:
         print("Recognizing...")


### PR DESCRIPTION
By deleting "tokens=2500" from line 63, and deleting all of lines 73-75.. (those lines actually dont do anything other than limit the output per response), we get a prediction of -1 (instead of 2500 limit) which is by default indicating that the model should generate predictions without a predetermined limit per response - as seen on the LM studio server terminal.
Its not context length, its per response (which i confirm in the LM studio logging when executed via terminal).
Line 76 'temp' actually does override Lm studio inference setting on that one. 

Also added 15 seconds to the speech listener before it cuts off.  Works a little better.

Defaulted the port to LM-Studio default config as well.

Also simplying pressing Enter key in a blank prompt will activate the speech. No need for shift+enter.

![without_tokens=2500](https://github.com/webmaster-exit-1/terminal-assistant/assets/89754687/8b60db59-e567-49e5-8f7b-2fcd20f456e9)
![with_tokens=2500](https://github.com/webmaster-exit-1/terminal-assistant/assets/89754687/52394838-ca5d-4eb6-8d2d-bda8c8ef9867)
